### PR TITLE
Minor fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,11 @@ plugins {
 	id 'java'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 def ENV = System.getenv()
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+}

--- a/src/main/java/org/lwjgl/opengl/Display.java
+++ b/src/main/java/org/lwjgl/opengl/Display.java
@@ -303,7 +303,7 @@ public class Display {
                 // Also, the workaround loses focus and doesn't always work
                 // TODO 
                 // GLFW.glfwSetWindowAttrib(handle, GLFW.GLFW_DECORATED, 0);
-                GLFW.glfwSetWindowMonitor(handle, MemoryUtil.NULL, x, y, current_mode.getWidth(), current_mode.getHeight(), current_mode.getFrequency());
+                GLFW.glfwSetWindowMonitor(handle, MemoryUtil.NULL, getWindowX(), getWindowY(), current_mode.getWidth(), current_mode.getHeight(), current_mode.getFrequency());
                 GLFW.glfwSetWindowSize(handle, current_mode.getWidth(), current_mode.getHeight());
                 // GLFW.glfwSetWindowAttrib(handle, GLFW.GLFW_DECORATED, 1);
             }

--- a/src/main/java/org/mcphackers/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
+++ b/src/main/java/org/mcphackers/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
@@ -173,6 +173,9 @@ public class GLFWMouseImplementation implements MouseImplementation {
         }
         this.grab = grab;
         GLFW.glfwSetInputMode(this.windowHandle, GLFW.GLFW_CURSOR, grab ? GLFW.GLFW_CURSOR_DISABLED : GLFW.GLFW_CURSOR_NORMAL);
+        if (grab) {
+            this.isInsideWindow = true;
+        }
         this.reset();
     }
 


### PR DESCRIPTION
Thanks for the work on this project; it's been extremely useful in porting my mod to older Minecraft versions without having to explicitly abstract out LWJGL 2/3 compatibility or use a preprocessor to switch code between them. This PR includes fixes for two issues I'm encountering regularly running my mod in dev.

* The game window would get created in the top-left corner of the screen, rather than the center as intended, due to the default window X/Y position not being calculated in `setDisplayModeAndFullscreenInternal`.
* The player camera would sometimes be immovable when first joining a world till the window is unfocused and refocused. It seems the `isInsideWindow` flag isn't consistently set when the mouse is first grabbed, so I set it manually. I think this is a correct fix since a grabbed mouse should always be within the window initially.

 I also upgraded the Gradle version to 8.14 (the latest) and fixed the buildscript so I can run Gradle with Java 21 while still producing a Java 8 library. (The `sourceCompatibility` directive isn't enough as the newer Java compiler can still generate bytecode for some NIO buffer methods that isn't compatible with Java 8.)